### PR TITLE
feat!: bump Adjust SDK to the latest v5.1.0

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -86,4 +86,4 @@ jobs:
           github_token: ${{ secrets.PAT }}
           pr_title: "chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master"
           pr_body: ":crown: *An automated PR*\n\n${{ steps.finish-release.outputs.commit_summary }}"
-          pr_reviewer: 'pallabmaiti'
+          pr_reviewer: '@rudderlabs/sdk-ios'

--- a/.github/workflows/manage-github-issue-for-outdated-pods.yml
+++ b/.github/workflows/manage-github-issue-for-outdated-pods.yml
@@ -19,7 +19,6 @@ jobs:
           outdated-pod-names: "Adjust"
           directory: "Example"
           title: "fix: update Adjust SDK to the latest version"
-          assignee: "desusai7"
           labels: "outdatedPod"
           color: "FBCA04"
         env:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pallabmaiti @itsdebs
+* @rudderlabs/sdk-ios

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,13 +1,11 @@
 use_frameworks!
 
-platform :ios, '8.0'
+platform :ios, '12.0'
 
 target 'Rudder-Adjust_Example' do
   pod 'Rudder-Adjust', :path => '../'
 
   target 'Rudder-Adjust_Tests' do
     inherit! :search_paths
-
-    pod 'FBSnapshotTestCase'
   end
 end

--- a/Example/Rudder-Adjust.xcodeproj/project.pbxproj
+++ b/Example/Rudder-Adjust.xcodeproj/project.pbxproj
@@ -226,7 +226,6 @@
 				6003F5AA195388D20070C39A /* Sources */,
 				6003F5AB195388D20070C39A /* Frameworks */,
 				6003F5AC195388D20070C39A /* Resources */,
-				974BB9006AD69DA16F8F8CF4 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -321,24 +320,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		974BB9006AD69DA16F8F8CF4 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Rudder-Adjust_Tests/Pods-Rudder-Adjust_Tests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/FBSnapshotTestCase/FBSnapshotTestCase.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSnapshotTestCase.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Rudder-Adjust_Tests/Pods-Rudder-Adjust_Tests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		ABE207811F1BF2DFBC91AC01 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -346,15 +327,23 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Rudder-Adjust_Example/Pods-Rudder-Adjust_Example-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Adjust/Adjust.framework",
+				"${BUILT_PRODUCTS_DIR}/Adjust/AdjustSdk.framework",
+				"${BUILT_PRODUCTS_DIR}/MetricsReporter/MetricsReporter.framework",
+				"${BUILT_PRODUCTS_DIR}/RSCrashReporter/RSCrashReporter.framework",
 				"${BUILT_PRODUCTS_DIR}/Rudder/Rudder.framework",
 				"${BUILT_PRODUCTS_DIR}/Rudder-Adjust/Rudder_Adjust.framework",
+				"${BUILT_PRODUCTS_DIR}/RudderKit/RudderKit.framework",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/AdjustSignature/AdjustSigSdk.framework/AdjustSigSdk",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Adjust.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AdjustSdk.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MetricsReporter.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RSCrashReporter.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Rudder.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Rudder_Adjust.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RudderKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AdjustSigSdk.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Example/Rudder-Adjust/RUDDERAppDelegate.m
+++ b/Example/Rudder-Adjust/RUDDERAppDelegate.m
@@ -22,7 +22,8 @@
     
     RSConfigBuilder *configBuilder = [[RSConfigBuilder alloc] init];
     [configBuilder withDataPlaneUrl:dataPlaneUrl];
-    [configBuilder withLoglevel:RSLogLevelDebug];
+    [configBuilder withLoglevel:RSLogLevelVerbose];
+    [configBuilder withTrackLifecycleEvens:false];
     [configBuilder withFactory:[RudderAdjustFactory instance]];
     RSClient *rudderClient = [RSClient getInstance:writeKey config:[configBuilder build]];
     

--- a/Example/Rudder-Adjust/RUDDERAppDelegate.m
+++ b/Example/Rudder-Adjust/RUDDERAppDelegate.m
@@ -17,11 +17,11 @@
 {
     // Override point for customization after application launch.
     
-    NSString *writeKey = @"1WC1fQ3nIuFlZcKYCN2zLirPq4D";
-    NSString *endPointUrl = @"https://843fa4c8.ngrok.io";
+    NSString *writeKey = @"<write_key>";
+    NSString *dataPlaneUrl = @"<dataPlane_url>";
     
     RSConfigBuilder *configBuilder = [[RSConfigBuilder alloc] init];
-    [configBuilder withDataPlaneUrl:endPointUrl];
+    [configBuilder withDataPlaneUrl:dataPlaneUrl];
     [configBuilder withLoglevel:RSLogLevelDebug];
     [configBuilder withFactory:[RudderAdjustFactory instance]];
     RSClient *rudderClient = [RSClient getInstance:writeKey config:[configBuilder build]];
@@ -30,9 +30,15 @@
         NSLog(@"processor started");
         
         usleep(10000000);
-        [rudderClient track:@"level_up"];
-        [rudderClient track:@"daily_rewards_claim"];
-        [rudderClient track:@"revenue"];
+        [rudderClient identify:@"RudderStack iOS user id"];
+        [rudderClient track:@"Track event iOS" properties:@{
+            @"key1": @"value1",
+            @"key2": @123,
+            @"key3": @YES,
+            @"key4": @4.56,
+            @"revenue": @"4.99",
+            @"currency": @"USD"
+        }];
     });
     
     return YES;

--- a/Rudder-Adjust.podspec
+++ b/Rudder-Adjust.podspec
@@ -13,14 +13,13 @@ Rudder is a platform for collecting, storing and routing customer event data to 
 
   s.homepage         = 'https://github.com/rudderlabs/rudder-integration-adjust-ios'
   s.license          = { :type => "ELv2", :file => "LICENSE.md" }
-  s.author           = { 'RudderStack' => 'arnab@rudderlabs.com' }
+  s.author           = { 'RudderStack' => 'sdk@rudderstack.com' }
   s.source           = { :git => 'https://github.com/rudderlabs/rudder-integration-adjust-ios.git', :tag => "v#{s.version}" }
-  s.platform         = :ios, "9.0"
 
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '12.0'
 
   s.source_files = 'Rudder-Adjust/Classes/**/*'
 
-  s.dependency 'Rudder'
-  s.dependency 'Adjust'
+  s.dependency 'Rudder', '~> 1.29'
+  s.dependency 'Adjust', '~> 5.1.0'
 end

--- a/Rudder-Adjust/Classes/RudderAdjustIntegration.h
+++ b/Rudder-Adjust/Classes/RudderAdjustIntegration.h
@@ -7,7 +7,7 @@
 
 #import <Foundation/Foundation.h>
 #import <Rudder/Rudder.h>
-#import <Adjust/Adjust.h>
+#import <AdjustSdk/AdjustSdk.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Rudder-Adjust/Classes/RudderAdjustIntegration.m
+++ b/Rudder-Adjust/Classes/RudderAdjustIntegration.m
@@ -32,16 +32,16 @@
             }
             self.eventMap = tempDict;
         }
-        NSNumber *delayTime = [config objectForKey:@"delay"];
-        double delay = 0;
-        if (delayTime != nil) {
-            delay = [delayTime doubleValue];
-        }
-        if (delay < 0) {
-            delay = 0;
-        } else if (delay > 10) {
-            delay = 10;
-        }
+//        NSNumber *delayTime = [config objectForKey:@"delay"];
+//        double delay = 0;
+//        if (delayTime != nil) {
+//            delay = [delayTime doubleValue];
+//        }
+//        if (delay < 0) {
+//            delay = 0;
+//        } else if (delay > 10) {
+//            delay = 10;
+//        }
         
         if (apiToken != nil && ![apiToken isEqualToString:@""]) {
             NSString *environment = ADJEnvironmentProduction;
@@ -49,14 +49,15 @@
                 environment = ADJEnvironmentSandbox;
             }
             
-            ADJConfig *adjustConfig = [ADJConfig configWithAppToken:apiToken environment:environment];
+            ADJConfig *adjustConfig = [[ADJConfig alloc] initWithAppToken:apiToken environment:environment];//[ADJConfig configWithAppToken:apiToken environment:environment];
             [adjustConfig setLogLevel:rudderConfig.logLevel >= 4 ? ADJLogLevelVerbose : ADJLogLevelError];
-            [adjustConfig setEventBufferingEnabled:YES];
+//            [adjustConfig setEventBufferingEnabled:YES];
             [adjustConfig setDelegate:self];
-            if (delay > 0) {
-                [adjustConfig setDelayStart:delay];
-            }
-            [Adjust appDidLaunch:adjustConfig];
+//            if (delay > 0) {
+//                [adjustConfig setDelayStart:delay];
+//            }
+//            [Adjust appDidLaunch:adjustConfig];
+            [Adjust initSdk:adjustConfig];
         }
     }
     return self;
@@ -100,14 +101,19 @@
 }
 
 -(void) setPartnerParams:(RSMessage*) message {
-    [Adjust addSessionPartnerParameter:@"anonymousId" value:message.anonymousId];
+    [Adjust addGlobalPartnerParameter:@"anonymousId" forKey:message.anonymousId];
     if (message.userId != nil && ![message.userId isEqualToString:@""]) {
-        [Adjust addSessionPartnerParameter:@"userId" value:message.userId];
+        [Adjust addGlobalPartnerParameter:@"userId" forKey:message.userId];
     }
 }
 
 - (void)reset {
-    [Adjust resetSessionPartnerParameters];
+    [Adjust removeGlobalPartnerParameters];
 }
+
+- (void)flush { 
+    
+}
+
 
 @end

--- a/Rudder-Adjust/Classes/RudderAdjustIntegration.m
+++ b/Rudder-Adjust/Classes/RudderAdjustIntegration.m
@@ -72,28 +72,30 @@
         [self setPartnerParams:message];
     } else if ([message.type isEqualToString:@"track"]) {
         NSString *adjEventToken = [self.eventMap objectForKey:message.event];
-        if (adjEventToken != nil) {
-            [self setPartnerParams:message];
-            ADJEvent *event = [[ADJEvent alloc] initWithEventToken:adjEventToken];
-            NSDictionary *eventProperties = message.properties;
-            if (eventProperties != nil) {
-                for (NSString *key in [eventProperties allKeys]) {
-                    [event addCallbackParameter:key value:[NSString stringWithFormat:@"%@", [eventProperties objectForKey:key]]];
-                }
-                NSNumber *total = [eventProperties objectForKey:@"revenue"];
-                NSString *currency = [eventProperties objectForKey:@"currency"];
-                if (total != nil && currency != nil) {
-                    [event setRevenue:[total doubleValue] currency:currency];
-                }
-            }
-            NSDictionary *userProperties = message.userProperties;
-            if (userProperties != nil) {
-                for (NSString *key in [userProperties allKeys]) {
-                    [event addCallbackParameter:key value:[NSString stringWithFormat:@"%@", [userProperties objectForKey:key]]];
-                }
-            }
-            [Adjust trackEvent:event];
+        if (adjEventToken == nil) {
+            [RSLogger logDebug:[NSString stringWithFormat:@"Dropping the track event: %@, since corresponding event token is not present.", message.event]];
+            return;
         }
+        [self setPartnerParams:message];
+        ADJEvent *event = [[ADJEvent alloc] initWithEventToken:adjEventToken];
+        NSDictionary *eventProperties = message.properties;
+        if (eventProperties != nil) {
+            for (NSString *key in [eventProperties allKeys]) {
+                [event addCallbackParameter:key value:[NSString stringWithFormat:@"%@", [eventProperties objectForKey:key]]];
+            }
+            NSNumber *total = [eventProperties objectForKey:@"revenue"];
+            NSString *currency = [eventProperties objectForKey:@"currency"];
+            if (total != nil && currency != nil) {
+                [event setRevenue:[total doubleValue] currency:currency];
+            }
+        }
+        NSDictionary *userProperties = message.userProperties;
+        if (userProperties != nil) {
+            for (NSString *key in [userProperties allKeys]) {
+                [event addCallbackParameter:key value:[NSString stringWithFormat:@"%@", [userProperties objectForKey:key]]];
+            }
+        }
+        [Adjust trackEvent:event];
     } else {
         [RSLogger logWarn:@"MessageType is not specified"];
     }

--- a/Rudder-Adjust/Classes/RudderAdjustIntegration.m
+++ b/Rudder-Adjust/Classes/RudderAdjustIntegration.m
@@ -40,12 +40,28 @@
             }
             
             ADJConfig *adjustConfig = [[ADJConfig alloc] initWithAppToken:apiToken environment:environment];
-            [adjustConfig setLogLevel:rudderConfig.logLevel >= 4 ? ADJLogLevelVerbose : ADJLogLevelError];
+            [self setLogLevel:rudderConfig.logLevel withAdjustConfig:adjustConfig];
             [adjustConfig setDelegate:self];
             [Adjust initSdk:adjustConfig];
         }
     }
     return self;
+}
+
+- (void)setLogLevel:(int) loglevel withAdjustConfig:(ADJConfig *)adjustConfig {
+    if (loglevel == RSLogLevelVerbose) {
+        [adjustConfig setLogLevel:ADJLogLevelVerbose];
+    } else if (loglevel == RSLogLevelDebug) {
+        [adjustConfig setLogLevel:ADJLogLevelDebug];
+    } else if (loglevel == RSLogLevelInfo) {
+        [adjustConfig setLogLevel:ADJLogLevelInfo];
+    } else if (loglevel == RSLogLevelWarning) {
+        [adjustConfig setLogLevel:ADJLogLevelWarn];
+    } else if (loglevel == RSLogLevelError) {
+        [adjustConfig setLogLevel:ADJLogLevelError];
+    } else {
+        [adjustConfig setLogLevel:ADJLogLevelSuppress];
+    }
 }
 
 - (void)dump:(nonnull RSMessage *)message {

--- a/Rudder-Adjust/Classes/RudderAdjustIntegration.m
+++ b/Rudder-Adjust/Classes/RudderAdjustIntegration.m
@@ -32,16 +32,6 @@
             }
             self.eventMap = tempDict;
         }
-//        NSNumber *delayTime = [config objectForKey:@"delay"];
-//        double delay = 0;
-//        if (delayTime != nil) {
-//            delay = [delayTime doubleValue];
-//        }
-//        if (delay < 0) {
-//            delay = 0;
-//        } else if (delay > 10) {
-//            delay = 10;
-//        }
         
         if (apiToken != nil && ![apiToken isEqualToString:@""]) {
             NSString *environment = ADJEnvironmentProduction;
@@ -49,14 +39,9 @@
                 environment = ADJEnvironmentSandbox;
             }
             
-            ADJConfig *adjustConfig = [[ADJConfig alloc] initWithAppToken:apiToken environment:environment];//[ADJConfig configWithAppToken:apiToken environment:environment];
+            ADJConfig *adjustConfig = [[ADJConfig alloc] initWithAppToken:apiToken environment:environment];
             [adjustConfig setLogLevel:rudderConfig.logLevel >= 4 ? ADJLogLevelVerbose : ADJLogLevelError];
-//            [adjustConfig setEventBufferingEnabled:YES];
             [adjustConfig setDelegate:self];
-//            if (delay > 0) {
-//                [adjustConfig setDelayStart:delay];
-//            }
-//            [Adjust appDidLaunch:adjustConfig];
             [Adjust initSdk:adjustConfig];
         }
     }

--- a/Rudder-Adjust/Classes/RudderAdjustIntegration.m
+++ b/Rudder-Adjust/Classes/RudderAdjustIntegration.m
@@ -94,8 +94,6 @@
             }
             [Adjust trackEvent:event];
         }
-    } else if ([message.type isEqualToString:@"screen"]) {
-        [RSLogger logWarn:@"MessageType is not supported"];
     } else {
         [RSLogger logWarn:@"MessageType is not specified"];
     }


### PR DESCRIPTION
# Description

- Updated the Adjust iOS SDK version to `5.1.0`.
- Set 1.29 as the minimum Rudder-iOS version for the Rudder-Adjust SDK.
- Updated the iOS target to `12.0`. Adjust now supports the minimum version of 12.0.
- Updated code owners and reviewers.
- Address breaking changes:
    - Removed the [adjustConfig setDelayStart](https://dev.adjust.com/en/sdk/migration/ios/v4-to-v5#delay-sdk-start)
    - Removed the [adjustConfig setEventBufferingEnabled](https://dev.adjust.com/en/sdk/migration/ios/v4-to-v5#event-buffering)
    - Update the following settings:
        - Adjust appDidLaunch to Adjust initSdk
        - ADJConfig configWithAppToken to [ADJConfig alloc] initWithAppToken
        - Adjust addSessionPartnerParameter to Adjust addGlobalPartnerParameter
        - Adjust resetSessionPartnerParameters to Adjust removeGlobalPartnerParameters
