### PR TITLE
ci: use shas for external github actions

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -79,7 +79,7 @@ jobs:
           git push --follow-tags
 
       - name: Create pull request into master
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 #v2
         with:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: 'master'

--- a/.github/workflows/notion-pr-sync.yml
+++ b/.github/workflows/notion-pr-sync.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Sync Github PRs to Notion
-        uses: sivashanmukh/github-notion-pr-sync@1.0.0
+        uses: sivashanmukh/github-notion-pr-sync@3967330238449a8550b06f6e1d6b83e1af569876 #v1.0.0
         with:
           notionKey: ${{ secrets.NOTION_BOT_KEY }}
           notionDatabaseId: ${{ secrets.NOTION_PR_DB_ID }}


### PR DESCRIPTION
# Description

- Using SHA's for these two actions:
```
repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 #v2

sivashanmukh/github-notion-pr-sync@3967330238449a8550b06f6e1d6b83e1af569876 #v1.0.0
```
