### PR TITLE
feat: add SPM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ Carthage/Build
 #
 Pods/
 Podfile.lock
+
+.build/

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,61 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "AdjustSignature",
+        "repositoryURL": "https://github.com/adjust/adjust_signature_sdk.git",
+        "state": {
+          "branch": null,
+          "revision": "93c40d7fa27b709a81adc50e41b400ce4411c7ff",
+          "version": "3.35.2"
+        }
+      },
+      {
+        "package": "RSCrashReporter",
+        "repositoryURL": "https://github.com/rudderlabs/crash-reporter-ios",
+        "state": {
+          "branch": null,
+          "revision": "ee563535b64d9d5feacd0fa243663b2658033a19",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "package": "AdjustSdk",
+        "repositoryURL": "https://github.com/adjust/ios_sdk",
+        "state": {
+          "branch": null,
+          "revision": "1ac4d02d66033411e612571a7b8a7b20b0896e1c",
+          "version": "5.1.0"
+        }
+      },
+      {
+        "package": "MetricsReporter",
+        "repositoryURL": "https://github.com/rudderlabs/metrics-reporter-ios",
+        "state": {
+          "branch": null,
+          "revision": "e307fa37c6c2d2cccf787d73b5b4b5bc3f650435",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "package": "RudderKit",
+        "repositoryURL": "https://github.com/rudderlabs/rudder-ios-kit",
+        "state": {
+          "branch": null,
+          "revision": "8a557a80cc1b0e0bc948c2b17fe0fd3809bcfd61",
+          "version": "1.4.0"
+        }
+      },
+      {
+        "package": "Rudder",
+        "repositoryURL": "https://github.com/rudderlabs/rudder-sdk-ios",
+        "state": {
+          "branch": null,
+          "revision": "2543f659cfc1b772999f932ded1b210f94faeb0c",
+          "version": "1.31.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "Rudder-Adjust",
+    platforms: [
+        .iOS("12.0"), .tvOS("12.0")
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "Rudder-Adjust",
+            targets: ["Rudder-Adjust"]),
+    ],
+    dependencies: [
+        .package(name: "Adjust", url: "https://github.com/adjust/ios_sdk", .exact("5.1.0")),
+        .package(name: "Rudder", url: "https://github.com/rudderlabs/rudder-sdk-ios", from: "1.0.0"),
+    ],
+
+    targets: [
+        .target(
+            name: "Rudder-Adjust",
+            dependencies: [
+                .product(name: "Adjust", package: "Adjust"),
+                .product(name: "Rudder", package: "Rudder"),
+            ],
+            path: "Rudder-Adjust",
+            sources: ["Classes/"],
+            publicHeadersPath: "Classes/",
+            cSettings: [
+                .headerSearchPath("Classes/")
+            ]
+        ),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["Rudder-Adjust"]),
     ],
     dependencies: [
-        .package(name: "Adjust", url: "https://github.com/adjust/ios_sdk", .exact("5.1.0")),
+        .package(name: "AdjustSdk", url: "https://github.com/adjust/ios_sdk", .exact("5.1.0")),
         .package(name: "Rudder", url: "https://github.com/rudderlabs/rudder-sdk-ios", from: "1.0.0"),
     ],
 
@@ -22,7 +22,7 @@ let package = Package(
         .target(
             name: "Rudder-Adjust",
             dependencies: [
-                .product(name: "Adjust", package: "Adjust"),
+                .product(name: "AdjustSdk", package: "AdjustSdk"),
                 .product(name: "Rudder", package: "Rudder"),
             ],
             path: "Rudder-Adjust",

--- a/Rudder-Adjust/Classes/RudderAdjustFactory.h
+++ b/Rudder-Adjust/Classes/RudderAdjustFactory.h
@@ -6,7 +6,11 @@
 //
 
 #import <Foundation/Foundation.h>
+#if defined(__has_include) && __has_include(<Rudder/Rudder.h>)
 #import <Rudder/Rudder.h>
+#else
+#import "Rudder.h"
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Rudder-Adjust/Classes/RudderAdjustIntegration.h
+++ b/Rudder-Adjust/Classes/RudderAdjustIntegration.h
@@ -6,7 +6,11 @@
 //
 
 #import <Foundation/Foundation.h>
+#if defined(__has_include) && __has_include(<Rudder/Rudder.h>)
 #import <Rudder/Rudder.h>
+#else
+#import "Rudder.h"
+#endif
 #import <AdjustSdk/AdjustSdk.h>
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
# Description

- Added SPM support.
- Added `.build/` in gitignore.
- In Factory classes, we have to change the import from `#import <Rudder/Rudder.h>` to the following code: This is required to address the build failure happening when this package is integrated using SPM. In case, if we don't add this then there will be build failure.
```
#if defined(__has_include) && __has_include(<Rudder/Rudder.h>)
#import <Rudder/Rudder.h>
#else
#import "Rudder.h"
#endif
```
- NOTE: I've tested the above changes by integrating it through both CocoaPod way and SPM.
- We already have a similar change in the [AppsFlyer-v1](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/blob/7f7b92b56f1369ff3458d32a01b253320d8340c3/Rudder-Appsflyer/Classes/RudderAppsflyerFactory.h#L9C1-L13C7) repo.
- I've used `AdjustSdk` instead of `Adjust`, as from v5 their Package.swift mention that as the package name, refer [here](https://github.com/adjust/ios_sdk/blob/a32b766c9d798dbdfd90cc692060359bf777c654/Package.swift#L6). CocoaPods still uses the old name.