### PR TITLE
fix: correct userId and anonymousId parameter mapping in Adjust addGlobalPartnerParameter API

### DIFF
--- a/Rudder-Adjust/Classes/RudderAdjustIntegration.m
+++ b/Rudder-Adjust/Classes/RudderAdjustIntegration.m
@@ -102,9 +102,9 @@
 }
 
 -(void) setPartnerParams:(RSMessage*) message {
-    [Adjust addGlobalPartnerParameter:@"anonymousId" forKey:message.anonymousId];
+    [Adjust addGlobalPartnerParameter:message.anonymousId forKey:@"anonymousId"];
     if (message.userId != nil && ![message.userId isEqualToString:@""]) {
-        [Adjust addGlobalPartnerParameter:@"userId" forKey:message.userId];
+        [Adjust addGlobalPartnerParameter:message.userId forKey:@"userId"];
     }
 }
 


### PR DESCRIPTION
# Description

### Fixed
- Fixed issue where userId and anonymousId were not set correctly in Adjust partner parameters
  - Corrected parameter order in `setPartnerParams` method in `RudderAdjustIntegration.m`
  - Fixed `addGlobalPartnerParameter` calls to pass the actual user ID and anonymous ID values as parameters instead of the key names
  - This ensures that the correct user identifiers are sent to Adjust for proper user tracking

### Technical Changes
```diff
- [Adjust addGlobalPartnerParameter:@"anonymousId" forKey:message.anonymousId];
+ [Adjust addGlobalPartnerParameter:message.anonymousId forKey:@"anonymousId"];

- [Adjust addGlobalPartnerParameter:@"userId" forKey:message.userId];
+ [Adjust addGlobalPartnerParameter:message.userId forKey:@"userId"];
```

The fix swapped the parameter order to correctly pass the actual ID values as the parameter values and the key names as the keys, ensuring proper integration with the Adjust SDK.

