### PR TITLE
feat: add enableInstallAttributionTracking toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## 2.2.0-beta.1 (2025-09-04)
-
-
-### Features
-
-* add install attribution support ([#18](https://github.com/rudderlabs/rudder-integration-adjust-ios/issues/18)) ([5a94c0b](https://github.com/rudderlabs/rudder-integration-adjust-ios/commit/5a94c0b5389bd001a98e846ea4dc4ba79599651d))
-
 ### 2.1.1 (2025-07-07)
 
 

--- a/Rudder-Adjust/Classes/RudderAdjustIntegration.m
+++ b/Rudder-Adjust/Classes/RudderAdjustIntegration.m
@@ -41,8 +41,11 @@
             
             ADJConfig *adjustConfig = [[ADJConfig alloc] initWithAppToken:apiToken environment:environment];
             [self setLogLevel:rudderConfig.logLevel withAdjustConfig:adjustConfig];
-            // TODO: Add boolean check to conditionally set Adjust delegate for attribution tracking
-            [adjustConfig setDelegate:self];
+            // Check if install attribution tracking is enabled via dashboard configuration
+            BOOL enableInstallAttributionTracking = [[config objectForKey:@"enableInstallAttributionTracking"] boolValue];
+            if (enableInstallAttributionTracking) {
+                [adjustConfig setDelegate:self];
+            }
             [Adjust initSdk:adjustConfig];
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.2.0-beta.1",
+    "version": "2.1.1",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }


### PR DESCRIPTION
# Description

## Description
This PR implements configurable install attribution tracking for the Adjust iOS integration, adding a dashboard toggle (`enableInstallAttributionTracking`) that allows users to control whether install attribution events are tracked. The feature is disabled by default (production version) and builds incrementally on the existing install attribution implementation from the beta version.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimisation

## Implementation Details

### Configuration Toggle Implementation
The implementation centers around a single boolean configuration parameter `enableInstallAttributionTracking` that controls whether the Adjust SDK delegate is set during initialisation. This elegant approach provides complete control over attribution tracking:

- **When disabled (default)**: No delegate is set, so `adjustAttributionChanged:` callback never fires → no attribution events tracked
- **When enabled**: Delegate is set normally, enabling the full install attribution functionality from the beta version

### Technical Approach
- **Conditional Delegate Setup**: Replaced the unconditional `[adjustConfig setDelegate:self]` with a conditional block that checks the configuration value
- **Dashboard Integration**: Reads the toggle state from the standard RudderStack configuration dictionary using `[[config objectForKey:@"enableInstallAttributionTracking"] boolValue]`
- **Default Behaviour**: When the configuration key is missing or false, attribution tracking is disabled (production requirement)
- **Version Management**: Reverted beta version changes to maintain stable release versioning

## How to test?

1. **Test with toggle disabled (default behaviour)**:
   ```json
   // In RudderStack dashboard config, either omit the key or set:
   "enableInstallAttributionTracking": false
   ```
   - Verify no "Install Attributed" events are generated
   - Confirm Adjust delegate is not set during initialisation

2. **Test with toggle enabled**:
   ```json
   // In RudderStack dashboard config:
   "enableInstallAttributionTracking": true
   ```
   - Verify "Install Attributed" events are generated as expected
   - Confirm attribution data includes all expected properties (provider, trackerToken, campaign details)